### PR TITLE
fix cmk.gui.plugins.wato import in en

### DIFF
--- a/en/devel_check_plugins.asciidoc
+++ b/en/devel_check_plugins.asciidoc
@@ -1906,7 +1906,7 @@ Next, symbols are imported that are needed for registration:
 
 [{python}]
 ----
-from cmk.gui.plugins.wato import (
+from cmk.gui.plugins.wato.utils import (
     CheckParameterRulespecWithItem,
     rulespec_registry,
     RulespecGroupCheckParametersOperatingSystem,


### PR DESCRIPTION
In the newest version of checkmk the import in wato rules is cmk.gui.plugins.wato.utils, not cmk.gui.plugins.wato