### PR TITLE
fix cmk.gui.plugins.wato import in de

### DIFF
--- a/de/devel_check_plugins.asciidoc
+++ b/de/devel_check_plugins.asciidoc
@@ -1976,7 +1976,7 @@ benötigt werden:
 
 [{python}]
 ----
-from cmk.gui.plugins.wato import (
+from cmk.gui.plugins.wato.utils import (
     CheckParameterRulespecWithItem,
     rulespec_registry,
     RulespecGroupCheckParametersOperatingSystem,


### PR DESCRIPTION
In the newest version of checkmk the import in wato rules is cmk.gui.plugins.wato.utils, not cmk.gui.plugins.wato