### PR TITLE
Update agent_freebsd.asciidoc

### DIFF
--- a/src/common/en/agent_freebsd.asciidoc
+++ b/src/common/en/agent_freebsd.asciidoc
@@ -269,7 +269,6 @@ image::agent_freebsd_local.png[alt="List with the newly detected service Hello B
 |`/var/spool/check_mk_agent` |Contains data that is created by cronjobs, for example, and includes its own section. These are also appended to the agent output.
 |`/etc/check_mk` |Storage location for the agent's configuration files.
 |`/etc/check_mk/mrpe.cfg` |Configuration file for xref:agent_linux#mrpe[MRPE] -- for running classic Nagios compatible check plug-ins.
-|`/etc/check_mk/exclude_sections.cfg` |Configuration file for  xref:agent_linux#disabled_sections[disabling specified sections] of the agent.
 |===
 
 *Attention:* There are no default file paths defined for FreeBSD, as there are for Linux below `/var/lib/check_mk_agent`.


### PR DESCRIPTION
Remove mention of  exclude_sections.cfg. The FreeBSD version does not support this. 

See 
  * https://github.com/Checkmk/checkmk/blob/master/agents/check_mk_agent.freebsd
  * https://forum.checkmk.com/t/freebsd-exclude-sections/43444