### PR TITLE
Fixed OpenShift token commands

### DIFF
--- a/src/common/en/monitoring_openshift.asciidoc
+++ b/src/common/en/monitoring_openshift.asciidoc
@@ -136,20 +136,11 @@ The following command can be used to read out the token, which is usually the on
 
 [{shell}]
 ----
-{c-user} oc get secret $(oc get serviceaccount checkmk -o=jsonpath='{.secrets[0].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode
+{c-user} oc get secret $(oc describe sa checkmk -n checkmk-monitoring | grep 'Tokens' | awk '{ print $2 }') -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode
 eyJhbGciOiJSUzI1NiIsImtpZCI6IkxFbDdZb25t...
 ----
 
 Leave the shell open with this information or copy the token to a location that you can access during the following setup in {CMK}.
-
-*Note:* The service account is created in OpenShift with two secrets. Since it is unpredictable which of these will contain the token, the output from the above command may simply be empty.
-In this case, change the index of the retrieved array element (the number in the square brackets following `.secrets`) from `0` to `1`:
-
-[{shell}]
-----
-{c-user} oc get secret $(oc get serviceaccount checkmk -o=jsonpath='{.secrets[1].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode
-----
-
 
 [#get_certificate]
 ==== Retrieve the certificate
@@ -158,7 +149,8 @@ The following command can be used to retrieve the certificate which you will lat
 
 [{shell}]
 ----
-{c-user} oc get secret $(oc get serviceaccount checkmk -o=jsonpath='{.secrets[0].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode
+{c-user} oc get secret $(oc describe sa checkmk -n checkmk-monitoring | grep 'Tokens' | awk '{ print $2 }') -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode
+
 ----
 
 Leave the shell open with this information, or copy the certificate -- including the `BEGIN CERTIFICATE` and `END CERTIFICATE` lines -- to a location that you can access during the following setup in {CMK}.


### PR DESCRIPTION
The commands were broken. These ones work.