### PR TITLE
Clearer documentation for SMART PING

### DIFF
--- a/src/common/en/cmc_differences.asciidoc
+++ b/src/common/en/cmc_differences.asciidoc
@@ -35,38 +35,33 @@ This sends, for example, five ping packets and waits for their return.
 Creating the processes for executing the plug-ins ties up valuable CPU resources.
 Furthermore, these can form a backlog for quite a long time if a host is not reachable, and long timeouts must be endured.
 
-By contrast, CMC runs host checks -- unless otherwise configured -- using a procedure called _Smart Ping_. 
-With this _a single_ ping packet is sent per host per interval.
-This is performed by an auxiliary process named `icmpsender` -- directly and without a process creation.
-For this purpose the `icmpsender` has its own ping implementation, which we have developed and which is markedly efficient.
-In benchmarking using only ping we could generate network traffic of up to 45 MBit/sec!
-The interval for pings per host is set to *six seconds* by default, 
-but you can redefine this via the [.guihint]#Normal check interval for host checks# rule set.
+By contrast, CMC runs host checks -- unless otherwise configured -- using a procedure called _Smart Ping_, _Smart Ping_ relies on an internal component called `icmpsender`, which has its own ping implementation. This way if we don't rely on an external binary, we don't need to spawn a new process for each ping packet sent, thus dramatically decreasing the resources overhead.
+Also the default behaviour of `icmpsender` differs from its Nagios counterpart. Instead of multiple packets in rapid series that are waited upon, `icmpsender` sends only _a single_ icmp packet per host once every n-seconds interval (defaults to 6 seconds) that is configurable via the [.guihint]#Normal check interval for host checks# rule set. This behaviour drastically reduces the amount of traffic going through the cable, which is benchmarked to be up to 45 MBit/sec! 
+The responses to the pings are not explicitly waited-for.
+There is an auxiliary process called `icmpreceiver` which is responsible for this.
 
-The responses to the pings are not explicitly waited-for. 
-Incoming ping packets are simply noted as successful checks. 
-The auxiliary process `icmpreceiver` is responsible for this.
-If no packet is received from a host within a defined time, this host will be flagged as {DOWN}.
-This timeout time is predefined at 15 seconds (2,5 intervals) and can also be altered per host via the [.guihint]#Settings for host checks via Smart PING# rule set.
+CMC's `icmpreceiver` component is responsible for marking a host as being {UP} or {DOWN}.
+`icmpreceiver` considers incoming ping packets from a host to be successful host checks, thus marking it as being {UP}. 
+If no packet is received from a host within a defined time, this host will be flagged as {DOWN}. This timeout time is predefined at 15 seconds (2,5 intervals) and can also be altered per host via the [.guihint]#Settings for host checks via Smart PING# rule set.
+`icmpreceiver` also listens to TCP SYN (synchronization) and RST (reset) packets coming from a host. If it receives such packages, the host is considered to be {UP}. This mechanism can generate flapping states of hosts in infrastructures where ICMP traffic is not allowed but TCP traffic is.
+`icmpreceiver` will ignore any SNMP packet because SNMP does not communicate over the TCP protocol but over UDP.
 
 
 [#no_on-demand_host_checks]
 === No on-demand host checks
 
 Host checks not only serve to trigger notifications in the case of a total host failure, but also to suppress xref:notifications#state_host[notifications of service problems] during the host's down time. 
-It is therefore important to quickly and accurately determine a host's condition in the event of a service problem.
-Even if it has not been long since the last host check, this result can already be out of date.
-For this, it is sufficient when directly after a host failure, by chance the service check is executed first, rather than the host check. 
-Even though it is down, the host would still be considered {UP} and the notification for the service would be sent -- erroneously.
+Service problems can arise and not be responsibility of the service itself, but rather of a failure condition of the host.
+It can happen that a host is actually down even if its last known state in Checkmk is {UP} as per the last host check result.
+In such condition multiple service checks could returns problems that depend on the hosts down state, resulting in the bad behaviour of sending a notification.
+It is therefore important to determine a host's condition first, in the event of a service problem.
 
 The CMC solves this problem very simply: 
-if during a service problem the host is in an {UP} state, then the next host check will simply be waited-for. 
-Due to the interval being very short at only six seconds, there is only a negligible delay to a notification -- if the host is still {UP} and therefore the notification needs to be sent for the service.
-The CMC uses an additional trick -- the `icmpreceiver` evaluates not only incoming ping responses, but also packets resulting from TCP connection establishments: SYN (synchronization) and RST (reset). 
-Keep in mind, that the `icmpreceiver` will ignore each and every SNMP packet as SNMP does not communicate over the TCP protocol but over UDP.
+if a service problem arises and the host is in an {UP} state, CMC will wait for the next host check. 
+Due to the interval being very short at only (by default) six seconds, there is only a negligible delay to a notification -- if the host is still {UP} and therefore the notification needs to be sent for the service.
 
 As an example, let's take the case of a `check_http` plug-in delivering a {CRIT} status, due to a queried web server being unavailable.
-In this situation, _following the start_ of the service check a TCP RST packet (_connection refused_) will be received from this server.
+In this situation, _following the start_ of the service check a TCP RST packet (_connection refused_) will be received from this server, which is listened for by the `icmpreceiver` component.
 The CMC therefore knows for certain that the host itself is {UP} and it can thus send the notification without delay.
 
 The same principle is utilized when calculating network outages if xref:notifications#parents[parent hosts] have been defined.


### PR DESCRIPTION
The paragraph "no on-demand host checks" is confusing and hides a detail about smart ping that should be immediately visible to the reader.

This commit restructures the "2. Smart Ping — Intelligent host checks" first sections keeping the meaning intact, and moves in the first section, the description of smart ping's behaviour of listening for TCP packets and not UDP packets.
The explanation of this behaviour is otherwise is hidden in the next paragraph, which could be easily overseen as thought as not connected to smart ping's description.

This issue is connected to [a thread](https://forum.checkmk.com/t/flapping-hosts-unable-to-smart-ping-but-reachable-on-the-agent-port/48909/1) in the community forum.
It affected me personally, but I'd be happy to nurse this PR if other members of the community had the same misunderstanding.