### PR TITLE
Capitalization of Scriptlet during imports

### DIFF
--- a/src/onprem/en/bakery_api.asciidoc
+++ b/src/onprem/en/bakery_api.asciidoc
@@ -148,7 +148,7 @@ from .bakery_api.v1 import (
    Plugin,
    PluginConfig,
    SystemBinary,
-   scriptlet,
+   Scriptlet,
    WindowsConfigEntry,
    register,
    FileGenerator,


### PR DESCRIPTION
Just noticed a typo in the bakery API docs. The class to be imported is `Scriptlet` rather than `scriptlet`.