### PR TITLE
Fixed location of AIX Local checks - should be /usr/lib/check_mk_agent/local

### DIFF
--- a/src/common/en/localchecks.asciidoc
+++ b/src/common/en/localchecks.asciidoc
@@ -517,7 +517,7 @@ These error messages should aid in quickly identifying errors in a script.
 |===
 |Path name |Operating system
 
-|`/usr/check_mk/lib/local/` |AIX
+|`/usr/lib/check_mk_agent/local/` |AIX
 |`/usr/local/lib/check_mk_agent/local/` |FreeBSD
 |`/usr/lib/check_mk_agent/local/` |HP-UX, Linux, OpenBSD, OpenWrt and Solaris
 |`%ProgramData%\checkmk\agent\local` |Windows


### PR DESCRIPTION
Fixed location of AIX Local checks - should be /usr/lib/check_mk_agent/local
I think it has been wrong since 1.8. And I think it will be the same error in 2.3. 