### PR TITLE
Clarified use of omd mv

### DIFF
--- a/src/onprem/de/omd_basics.asciidoc
+++ b/src/onprem/de/omd_basics.asciidoc
@@ -502,7 +502,7 @@ Die Reihenfolge der Option(en) ist dabei wichtig:
 === Instanzen umbenennen
 
 Das Umbenennen einer Instanz erfolgt mit dem Befehl `omd mv`.
-Dies geschieht analog zum xref:omd_cp[Kopieren einer Instanz], hat die gleichen Voraussetzungen und wird ebenfalls inklusive der xref:omd_cp_mv_migration[Migration der Konfiguration] durchgeführt.
+Dies geschieht analog zum xref:omd_cp[Kopieren einer Instanz], hat die gleichen Voraussetzungen und wird ebenfalls inklusive der xref:omd_cp_mv_migration[Migration der Konfiguration] durchgeführt. 
 Die Optionen zum Beschränken der Datenmengen existieren hier nicht, weil die Dateien ja einfach nur in ein anderes Verzeichnis verschoben und nicht dupliziert werden.
 
 Beispiel:
@@ -512,6 +512,9 @@ Beispiel:
 {c-root} omd mv mysite_old mysite_new
 ----
 
+Beim Umbenennen einer Instanz ändern sich einige Site-Attribute nicht, wie z.B. die Instance ID. 
+Es eignet sich somit nicht als Operation, um in einem verteilten Monitoring einzigartige Sites zu erstellen, welche z.B. durch einen Virtualisierungsmechanismus dupliziert wurden.
+Hierfür sollte `omd cp` verwendet werden.
 
 === Weitere Optionen
 

--- a/src/onprem/en/omd_basics.asciidoc
+++ b/src/onprem/en/omd_basics.asciidoc
@@ -511,6 +511,9 @@ Example:
 {c-root} omd mv mysite_old mysite_new
 ----
 
+When renaming a site, some site attributes do not change, such as the instance ID. 
+It is therefore not suitable as an operation to create unique sites in a distributed monitoring, which have been previously duplicated, e.g. by a virtualization mechanism.
+For this purpose, `omd cp` should be used.
 
 === Other options
 


### PR DESCRIPTION
License mgmt requires unique instance id's per site. 
User used omd mv for building a distributed monitoring using VM backups.
omd mv basically only renames the site, thus is not a suitable command for that.
