### PR TITLE
Agent_windows: Save user after randomizing password / Speichern des Users nach Auswürfeln des Passwords

### DIFF
--- a/src/common/de/agent_windows.asciidoc
+++ b/src/common/de/agent_windows.asciidoc
@@ -320,7 +320,7 @@ Wie Sie dies bewerkstelligen, zeigt dieses Kapitel.
 
 Die Registrierung und damit die Herstellung des gegenseitigen Vertrauensverhältnisses erfolgt unter einem {CMK}-Benutzer mit Zugriff auf die xref:rest_api#[REST-API.]
 Dafür bietet sich der xref:glossar#automation_user[Automationsbenutzer] `agent_registration` an, der nur die Berechtigung zur Registrierung von Agenten besitzt und bei jeder {CMK}-Installation automatisch angelegt wird.
-Das zugehörige Automationspasswort (_automation secret_) können Sie mit icon:icon_random[alt="Symbol zum Auswürfeln eines Passworts."] auswürfeln.
+Das zugehörige Automationspasswort (_automation secret_) können Sie mit icon:icon_random[alt="Symbol zum Auswürfeln eines Passworts."] auswürfeln. Beim Auswürfeln wird ein neues Passwort generiert. Sie müssen den Benutzer anschließend speichern, bevor Sie das neue Passwort nutzen können.
 
 *Hinweis:* Da es auf sehr alten xref:legacyagent[Windows-Systemen] keinen Agent Controller, und da mit keine Registrierung und TLS-Verschlüsselung gibt, 
 müssen Sie bei Bedarf andere Wege der Verschlüsselung wählen.

--- a/src/common/en/agent_windows.asciidoc
+++ b/src/common/en/agent_windows.asciidoc
@@ -315,7 +315,7 @@ This chapter shows how to perform the registration.
 
 The registration and thus the establishment of the mutual trust relationship is done under a {CMK} user with access to the xref:rest_api#[REST-API].
 For this, a good choice is the xref:glossar#automation_user[automation user] `agent_registration` which only has the permission to register agents and is automatically created with every {CMK} installation.
-You can randomize the corresponding automation password (_automation secret_) with the icon:icon_random[alt="Icon for rolling a password."] icon.
+You can randomize the corresponding automation password (_automation secret_) with the icon:icon_random[alt="Icon for rolling a password."] icon. The randomize function generates a new password. You must first save the user before using this new password.
 
 *Note:* Since there is no Agent Controller, and thus no registry and TLS encryption, on very old xref:legacyagent[Windows systems] you will need to use alternative encryption methods if required.
 In this case we recommend using the built-in (symmetric) encryption using the [.guihint]#Symmetric encryption (Linux, Windows)# rule.


### PR DESCRIPTION
Die Doku erklärt, wie das Password des agent_registration users rausgezogen werden kann, aber meldet nicht, dass der User nach dem "Rauswürfeln" gespeichert werden muss.