### PR TITLE
Fix image::timeperiods.png width

### DIFF
--- a/src/common/de/monitoring_basics.asciidoc
+++ b/src/common/de/monitoring_basics.asciidoc
@@ -388,7 +388,7 @@ Lesen Sie hierzu den Abschnitt über xref:checkinterval[Check-Intervalle.]
 == Zeiträume (Time periods)
 
 [{image-left}]
-image::timeperiods.png[width=8%]
+image::timeperiods.png
 
 Wöchentlich wiederkehrende Zeiträume kommen an verschiedenen Stellen in der Konfiguration zum Einsatz.
 Ein typischer Zeitraum könnte `work hours` heißen und die Zeiten von jeweils 8:00 bis 17:00 Uhr beinhalten, an allen Wochentagen außer Samstag und Sonntag.

--- a/src/common/en/monitoring_basics.asciidoc
+++ b/src/common/en/monitoring_basics.asciidoc
@@ -384,7 +384,7 @@ For this, read the section on xref:checkinterval[check intervals].
 == Time periods
 
 [{image-left}]
-image::timeperiods.png[width=8%]
+image::timeperiods.png
 
 Weekly recurring time periods are used in various places in the configuration.
 A typical time period could be called `working hours` and include the times from 8:00 to 17:00 each day, on all days of the week except Saturday and Sunday.


### PR DESCRIPTION
The calendar image is rendered with way too much space to its right before the text begins.
This change removes the width attribute to fix this.

Fixes: #99