### PR TITLE
Update agent_windows.asciidoc agent controller vs program

### DIFF
--- a/src/common/en/agent_windows.asciidoc
+++ b/src/common/en/agent_windows.asciidoc
@@ -24,8 +24,8 @@ With the release of {CMK} version {v21}, a new component, the *Agent Controller*
 The Agent Controller is upstream of the agent program, queries it and communicates with the {CMK} server in place of the agent program.
 To do this, the Agent Controller registers itself with the *Agent Receiver*, a process that runs on the {CMK} server.
 
-So, on the one hand, the Windows agent takes over the agent program, and thus also its advantages.
-On the other hand, it supplements the program so that new functions can be added, such as TLS encryption of communication or data compression.
+So, on the one hand, the Windows agent controller takes over the agent program, and thus also its advantages.
+On the other hand, the agent controller supplements the agent program so that new functions can be added, such as TLS encryption of communication or data compression.
 
 The registered, encrypted and compressed xref:glossar#pull_mode[pull mode] with the Agent Controller is available for all {CMK} editions
 -- provided both {CMK} server and agent have at least version {v21}.


### PR DESCRIPTION
Improve wording so "agent controller" vs "agent program" are more clear.