### PR TITLE
Fix: Update url to metrics.py to path before renaming

### DIFF
--- a/src/onprem/de/devel_check_plugins.asciidoc
+++ b/src/onprem/de/devel_check_plugins.asciidoc
@@ -1721,7 +1721,7 @@ Hier die Erklärung dazu:
 
 * Die verfügbaren Einheiten (`unit`) können Sie in der API-Dokumentation nachlesen, sie enden alle auf `Notation`, z. B. `DecimalNotation`, `EngineeringScientificNotation` oder `TimeNotation`.
 
-* Die in {CMK} verwendeten Farbnamen für die Farbdefinition `color` finden Sie auf link:https://github.com/Checkmk/checkmk/blob/{current-major}/packages/cmk-plugin-apis/cmk/graphing/v1/metrics.py[GitHub^].
+* Die in {CMK} verwendeten Farbnamen für die Farbdefinition `color` finden Sie auf link:https://github.com/Checkmk/checkmk/blob/{current-major}/packages/cmk-graphing/cmk/graphing/v1/metrics.py[GitHub^].
 
 Diese Definition in der Graphing-Datei sorgt jetzt dafür, dass Titel, Einheit und Farbe der Metrik angepasst dargestellt werden.
 

--- a/src/onprem/en/devel_check_plugins.asciidoc
+++ b/src/onprem/en/devel_check_plugins.asciidoc
@@ -1714,7 +1714,7 @@ Here is the explanation:
 
 * The available units (`unit`) can be found in the API documentation, these all end in `Notation`, e.g. `DecimalNotation`, `EngineeringScientificNotation` or `TimeNotation`.
 
-* The color names used in {CMK} for the `color` definition can be found at link:https://github.com/Checkmk/checkmk/blob/{current-major}/packages/cmk-plugin-apis/cmk/graphing/v1/metrics.py[GitHub^].
+* The color names used in {CMK} for the `color` definition can be found at link:https://github.com/Checkmk/checkmk/blob/{current-major}/packages/cmk-graphing/cmk/graphing/v1/metrics.py[GitHub^].
 
 This definition in the graphing file now ensures that the metric's title, unit and color are displayed appropriately.
 


### PR DESCRIPTION
The location for metrics.py has been changed in 2.5.0/master. The URL for 2.4.0 was already set to new location and results in a 404.